### PR TITLE
Allow micro-base/micro-suite to be required

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,0 +1,10 @@
+const isAsyncSupported = require('is-async-supported')
+const DEV = process.env.NODE_ENV === 'development'
+if (!isAsyncSupported()) {
+  require('async-to-gen/register')({
+    sourceMaps: DEV,
+    excludes: /\/node_modules\/(?!micro-suite\/)/
+  })
+}
+
+module.exports = require('./index.js')

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "tarik": "^1.0.2"
   },
   "dependencies": {
+    "async-to-gen": "^1.3.0",
+    "is-async-supported": "^1.2.0",
     "shortid": "^2.2.6",
     "uniloc": "^0.3.0"
   },


### PR DESCRIPTION
1. 1ad91f8

Allow micro-base to be required as node module by using `require('micro-suite/node')`.

`micro` (or rather, `async-to-gen`) currently excludes all files inside node_modules by default when transpiling async functions, with no way to override the exclude options via micro interface (cmiiw).

2. bbbae7f

Node.js lower-cases the headers [by default](https://nodejs.org/api/http.html#http_message_headers), so I added an additional check for `content-type`.
